### PR TITLE
Add rule to force trailing comma for multi-line statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = {
     'standard/object-curly-even-spacing': [2, 'either'],
     'standard/array-bracket-even-spacing': [2, 'either'],
     'standard/computed-property-even-spacing': [2, 'even'],
-    'standard/no-callback-literal': [2, ['cb', 'callback']]
+    'standard/no-callback-literal': [2, ['cb', 'callback']],
+    'comma-dangle': ['error', 'only-multiline'],
   },
   parser: 'babel-eslint',
   'plugins': [


### PR DESCRIPTION
This will bring 2 benefits:
  * Cleaner git diff, ie. adding 1 new element will make change only for that new line, which make it easier for seeing the change and PR review
  * Easier to change code, ie. add element to list without changing the previous line, especially help reduce unnecessary merge conflicts too.


Example can be found right in this commit change.
From this: 
```
   'standard/computed-property-even-spacing': [2, 'even'],
-  'standard/no-callback-literal': [2, ['cb', 'callback']]

   'standard/computed-property-even-spacing': [2, 'even'],
+  'standard/no-callback-literal': [2, ['cb', 'callback']],
+  "comma-dangle": ["error", "only-multiline"],
```

To this:
```
   'standard/computed-property-even-spacing': [2, 'even'],
   'standard/no-callback-literal': [2, ['cb', 'callback']],

   'standard/computed-property-even-spacing': [2, 'even'],
   'standard/no-callback-literal': [2, ['cb', 'callback']],
+  "comma-dangle": ["error", "only-multiline"],
```