### PR TITLE
Fix/dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package.json
   },
   "devDependencies": {
      ...
-     "eslint-config-viki-web-lint": "git+ssh://git@github.com/viki-org/viki-web-lint.git#<commit-ish>"
+     "eslint-config-viki-web-lint": "git+ssh://git@github.com/viki-org/viki-web-lint.git#<release-tag>"
      ...
   }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-viki-web-lint",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Viki's lint configs",
   "scripts": {
     "lint": "eslint ."
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "eslint": "^4.10.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^4.10.0",
     "eslint-config-standard": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.10.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-env": "0.0.3",
     "eslint-plugin-import": "^2.14.0",
@@ -24,5 +23,8 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.10.0"
   }
 }


### PR DESCRIPTION
By moving the packages that are required to dependencies allows npm to install them for you without the need of adding those packages to your project.